### PR TITLE
middlewares isadmin, isauth y generatetoken

### DIFF
--- a/api/src/middlewares/middlewares.js
+++ b/api/src/middlewares/middlewares.js
@@ -1,0 +1,41 @@
+import jwt from 'jsonwebtoken';
+
+export const generateToken = (user) => {
+  return jwt.sign(
+    {
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+      isAdmin: user.isAdmin,
+    },
+    process.env.JWT_SECRET,
+    {
+      expiresIn: '30d',
+    }
+  );
+};
+
+export const isAuth = (req, res, next) => {
+  const authorization = req.headers.authorization;
+  if (authorization) {
+    const token = authorization.slice(7, authorization.length); // Bearer XXXXXX
+    jwt.verify(token, process.env.JWT_SECRET, (err, decode) => {
+      if (err) {
+        res.status(401).send({ message: 'Invalid Token' });
+      } else {
+        req.user = decode;
+        next();
+      }
+    });
+  } else {
+    res.status(401).send({ message: 'No Token' });
+  }
+};
+
+export const isAdmin = (req, res, next) => {
+  if (req.user && req.user.isAdmin) {
+    next();
+  } else {
+    res.status(401).send({ message: 'Invalid Admin Token' });
+  }
+};


### PR DESCRIPTION
isadmin: sirve para que la ruta del back solo pueda ser usada por el admin (ej crear producto, dar de baja, etc)
isauth: sirve para validad el login del usuario y que pueda usar esa ruta
generatetoken: sirve para generar el JWT (json web token) que devuelve el back para que el usuario pueda ser validado